### PR TITLE
Enable CSS-loader and style-loader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 import my from "./modules/my.js"
+import "./modules/my.css"
+
 
 console.log("webpack")
 

--- a/src/modules/my.css
+++ b/src/modules/my.css
@@ -1,0 +1,8 @@
+body{
+  color: lightblue;
+}
+
+body *{
+  margin:0;
+  
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,21 @@
+const path=require("path")
+
+module.exports = {
+  entry: "./src/index.js",
+  output: {
+    path: path.resolve(__dirname,"./dist"),
+    filename: "index.js"
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css/,
+        use: [
+          { loader: "style-loader" },
+          { loader: "css-loader" },
+          // loaderは下から順番に処理されることに注意
+        ],
+      }
+    ],
+  },
+}


### PR DESCRIPTION
webpackでCSSを使えるようにするため、下記プラグインを有効化した。
- style-loader
- css-loader